### PR TITLE
Fix repository URLs and update version in package.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,5 +17,5 @@ Click the "Fork" button in the upper right corner of the repository to create yo
 Clone your forked repository to your local machine:
 
 ```bash
-git clone https://github.com/Nexoral/react-caches.git
+git clone https://github.com/nexoral/react-caches.git
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # React Caches
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![CodeQL](https://github.com/Nexoral/react-caches/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/Nexoral/react-caches/actions/workflows/github-code-scanning/codeql)
+[![CodeQL](https://github.com/nexoral/react-caches/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nexoral/react-caches/actions/workflows/github-code-scanning/codeql)
 
 React Caches is a lightweight and easy-to-use package that simplifies the management of local storage and cache storage in your React-based applications. With this package, you can easily access and manage data stored in local storage, cache storage, and other local storage used by JavaScript. It provides a convenient interface to store and retrieve data, making it seamless to work with client-side storage in your React projects.
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "react-caches",
-  "version": "5.4.11",
+  "version": "5.4.12",
   "description": "React Caches is a lightweight and easy-to-use package that provide you a simple way to use Local Storage, Session Storage, Caches Storage & Also provide Encryption & Decryption data alongside with outers package",
   "main": "./lib/config/react-caches.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Nexoral/react-caches.git"
+    "url": "git://github.com/nexoral/react-caches.git"
   },
   "types": "./lib/config/react-caches.d.ts",
   "author": "Ankan Saha",


### PR DESCRIPTION
This pull request updates all references to the GitHub repository to use the lowercase `nexoral` organization name instead of `Nexoral`. This ensures consistency and prevents potential issues with case sensitivity in URLs and badges. The package version is also incremented to reflect these changes.

Repository reference updates:

* Updated the repository URL in `package.json` to use `nexoral` instead of `Nexoral`.
* Changed the badge and workflow URLs in `README.md` to use the lowercase `nexoral` organization.
* Fixed the clone command in `CONTRIBUTING.md` to use the correct lowercase repository path.

Version update:

* Bumped the package version from `5.4.11` to `5.4.12` in `package.json` to reflect these repository reference changes.